### PR TITLE
fix: allow repository move when org updated

### DIFF
--- a/snyk_scm_mapper/models/sync.py
+++ b/snyk_scm_mapper/models/sync.py
@@ -116,7 +116,7 @@ class SnykWatchList(BaseModel):
 
             existing_repo = self.get_repo(repo.id)
 
-            if existing_repo.is_older(repo.updated_at):
+            if existing_repo.is_older(repo.updated_at) or existing_repo.org != org_name:
 
                 existing_repo.source = tmp_source
 
@@ -130,8 +130,7 @@ class SnykWatchList(BaseModel):
 
                 existing_repo.archived = archived
 
-                if org_name != "default":
-                    existing_repo.org = org_name
+                existing_repo.org = org_name
 
                 existing_repo.branches = branches
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [X] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)

### What this does

Updates an existing repository's organization name in the cache whenever the organization changes. This allows a repository to be imported into a new organization when the configuration changes, such as when a new topic is added to `snyk-orgs.yaml`.

With the previous behavior, it was impossible to move a project to a new organization. Even if the old project was deleted from Snyk, the old organization name would be cached by snyk-scm-manner and never updated since a update to the GitHub repository itself never occurred.

This change allows snyk-scm-mapper to import a GitHub repo into more than one Snyk organization, but only when an intentional configuration change to snyk-scm-mapper occurs.

### Notes for the reviewer

To test: 
* Set a topic on a GitHub repository.
* Configure snyk-scm-mapper without any topics.
* Clear the snyk-scm-mapper cache files.
* Run snyk-scm-mapper with the previous code once. 
* Verify the GitHub repository was imported to the default organization.
* Modify `snyk-orgs.yaml` and add the topic (the one previously set on the GitHub repository) to a different organization than the default one.. Do not modify the topics on the GitHub repo or any other repo setting at this step; we want the GitHub "repo updated date" to remain the same.
* Run snyk-scm-mapper with the previous code again. Leave the cache intact. Note how the repository was not imported to the new organization.

The next tests will be run with this PR's fix to verify the change:
* Run snyk-scm-mapper with this PR's code again. Leave the cache intact. Note how the repository was imported into the different organization (the one with the topic set).

### More information

The company I work for has a complex configuration for `snyk-scm-mapper` with around 15 different organizations. All of our imports are driven by GitHub topics - we have this change on a local fork so that we can update the configuration, but we'd rather get rid of our fork for the official version.

### Screenshots
